### PR TITLE
Avoid '429 Too Many Requests' from Valve's Web API

### DIFF
--- a/dota_bot/report.rb
+++ b/dota_bot/report.rb
@@ -10,13 +10,9 @@ module DotaBot
       print "  [REPORT] Preparing report from match id: #{last_seen_match_id}\n"
 
       # Collate matches from all players where two or more known players participated
-      threads = DotaBot::Player.all.map do |player|
-        Thread.new { player.matches }
-      end
+      DotaBot::Player.all.each { |p| p.matches }
 
-      threads.each(&:join)
-
-      DotaBot::Player.all.map do |player|
+      DotaBot::Player.all.each do |player|
         if last_seen_match_id != 0
           player.matches.select!{ |m| m.match_id > last_seen_match_id }
         else
@@ -29,11 +25,7 @@ module DotaBot
       matches.uniq!(&:match_id)
 
       # Load additional details for these matches we'll report on
-      threads = matches.map do |match|
-        Thread.new { match.load_match_details! }
-      end
-
-      threads.each(&:join)
+      matches.each { |m| m.load_match_details! }
 
       return if matches.empty?
 

--- a/dota_bot/steam_api.rb
+++ b/dota_bot/steam_api.rb
@@ -32,7 +32,20 @@ module DotaBot
       request_url = "#{url}?#{URI.encode_www_form(args)}"
 
       print "  [STEAM]  #{request_url}\n"
+      Kernel.sleep(1)
       JSON.parse(open(request_url).read)['result']
+
+
+    rescue OpenURI::HTTPError => ex
+      error_code = ex.io.status[0]
+
+      if error_code == '429'
+        # Sleep and retry
+        Kernel.sleep(5)
+        perform_request(url, args)
+      else
+        raise
+      end
     end
   end
 end


### PR DESCRIPTION
- Removed threaded behavior of the app, not required and makes life harder when dealing with the strict rate limiting of the Valve Web API.
- Added retry support when '429 Too Many Requests' is returned from the Web API.
